### PR TITLE
feat: add `GH_MATRIX` and `GH_STRATEGY` env variables

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,9 +41,11 @@ runs:
   using: "composite"
   steps:
     - shell: bash
+      env:
+        GH_MATRIX: "${{ toJson(matrix) }}"
+        GH_STRATEGY: "${{ toJson(strategy) }}"
       run: |
         # Configure and run codspeed-runner
-
         if [ -n "${{ inputs.runner-version }}" ]; then
           RUNNER_VERSION="${{ inputs.runner-version }}"
         else


### PR DESCRIPTION
We need these variables to be set in the environment to support splitting benchmarks between matrix jobs