### PR TITLE
Pin actions/cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ runs:
 
     - name: Cache CodSpeed instruments
       if: inputs.cache-instruments == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ${{ inputs.instruments-cache-dir }}
         key: codspeed-instruments-${{ runner.os }}-${{ runner.arch }}-${{steps.versions.outputs.kernel-version }}-${{ steps.versions.outputs.runner-version }}


### PR DESCRIPTION
GitHub recently added support for requiring actions to be pinned to a full-length commit SHA[^1].

Their changelog doesn't mention that composite actions also fail if their own actions are not pinned, which is the case for this project.

Hope this makes sense. I added the commit SHAs using [`pinact run action.yml`](https://github.com/suzuki-shunsuke/pinact).

[^1]: https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/
