### PR TITLE
feat: support pinning the codspeed-go-runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,8 @@ jobs:
             echo "Working";
             echo "with";
             echo "multiple lines";
-  test-version-formats:
+
+  test-runner-version-formats:
     strategy:
       fail-fast: false
       matrix:
@@ -88,4 +89,25 @@ jobs:
           allow-empty: true
           runner-version: ${{ matrix.version }}
           mode: simulation
+          run: echo "Testing version format ${{ matrix.version }}!"
+
+  test-go-runner-version-formats:
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - "1.0.0"
+          - "1.0.0-beta.1"
+
+    runs-on: ubuntu-latest
+    env:
+      CODSPEED_SKIP_UPLOAD: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check action with version format ${{ matrix.version }}
+        uses: ./
+        with:
+          allow-empty: true
+          go-runner-version: ${{ matrix.version }}
+          mode: walltime
           run: echo "Testing version format ${{ matrix.version }}!"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ GitHub Actions for running [CodSpeed](https://codspeed.io) in your CI.
     # [OPTIONAL]
     # A custom upload url, only if you are using an on premise CodSpeed instance
     upload-url: ""
+
+    # [OPTIONAL]
+    # The version of the go-runner to use (e.g., 1.0.0, 1.0.0-beta.1). If not specified, the latest version will be installed
+    go-runner-version: ""
 ```
 
 # Example usage

--- a/action.yml
+++ b/action.yml
@@ -73,6 +73,10 @@ inputs:
     required: false
     default: "false"
 
+  go-runner-version:
+    description: "The version of the go-runner to use (e.g., 1.0.0, 1.0.0-beta.1). If not specified, the latest version will be installed"
+    required: false
+
 runs:
   using: "composite"
   steps:
@@ -181,6 +185,9 @@ runs:
         fi
         if [ "${{ inputs.allow-empty }}" = "true" ]; then
           RUNNER_ARGS="$RUNNER_ARGS --allow-empty"
+        fi
+        if [ -n "${{ inputs.go-runner-version }}" ]; then
+          RUNNER_ARGS="$RUNNER_ARGS --go-runner-version=${{ inputs.go-runner-version }}"
         fi
 
         # Run the benchmarks


### PR DESCRIPTION
(the failing tests are only due to memory which doesn't support `allow-empty` at the moment, was fixed in https://github.com/CodSpeedHQ/runner/pull/205)

Depends on ~~https://github.com/CodSpeedHQ/codspeed/pull/213~~   https://github.com/CodSpeedHQ/action/pull/178