### PR TITLE
feat: skip hash check error when installing pre-release

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -104,6 +104,8 @@ runs:
         # Detect version type (priority: latest > version number > branch/rev prefixes)
         if [ "$RUNNER_VERSION" = "latest" ]; then
           VERSION_TYPE="latest"
+        elif echo "$RUNNER_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-'; then
+          VERSION_TYPE="prerelease"
         elif echo "$RUNNER_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
           VERSION_TYPE="release"
         elif echo "$RUNNER_VERSION" | grep -q '^branch:'; then
@@ -161,6 +163,12 @@ runs:
             echo "::warning::Hash verification is not available when using 'latest' version. Consider pinning a specific version for supply chain security."
           fi
           curl -fsSL https://codspeed.io/install.sh | bash -s -- --quiet
+        elif [ "$VERSION_TYPE" = "prerelease" ]; then
+          # Prereleases are not pinned, so install from the versioned installer without hash verification.
+          if [ "$SKIP_HASH_CHECK_WARNING" != "true" ]; then
+            echo "::warning::Hash verification is not available for prerelease version $RUNNER_VERSION."
+          fi
+          curl -fsSL "https://codspeed.io/v$RUNNER_VERSION/install.sh" | bash -s -- --quiet
         elif [ "$VERSION_TYPE" = "branch" ]; then
           # Install from specific branch using cargo
           if [ "$SKIP_HASH_CHECK_WARNING" != "true" ]; then


### PR DESCRIPTION
Install prerelease runner versions (e.g. `4.18.0-alpha.0`) without requiring a pinned installer hash.

Previously any semver-shaped `runner-version` was treated as a stable release and hard-failed with `No pinned hash found` when absent from `.codspeed-runner-installer-hashes.json`. Prereleases are cut for scoped dev-cycle testing and never go through the release flow that populates that list, so testing one always failed unless the JSON was hand-edited on a branch.

Prereleases are now detected as their own version type and installed from the versioned installer URL without hash verification — emitting a `::warning::`, the same treatment as `latest`/`branch`/`rev`. Stable releases missing a hash still hard-fail, preserving the supply-chain guarantee and still catching real release-process bugs.

Fixes COD-2883