### PR TITLE
docs: bump documented action version to v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ GitHub Actions for running [CodSpeed](https://codspeed.io) in your CI.
 # Usage
 
 ```yaml
-- uses: CodSpeedHQ/action@v4
+- uses: CodSpeedHQ/action@v5
   with:
     # [OPTIONAL]
     # The command used to run your CodSpeed benchmarks
@@ -117,7 +117,7 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@v4
+        uses: CodSpeedHQ/action@v5
         with:
           mode: simulation
           run: pytest tests/ --codspeed
@@ -162,7 +162,7 @@ jobs:
         run: cargo codspeed build
 
       - name: Run the benchmarks
-        uses: CodSpeedHQ/action@v4
+        uses: CodSpeedHQ/action@v5
         with:
           mode: simulation
           run: cargo codspeed run
@@ -202,7 +202,7 @@ jobs:
         run: npm install
 
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@v4
+        uses: CodSpeedHQ/action@v5
         with:
           mode: simulation
           run: npx vitest bench

--- a/examples/cpp-cmake-codspeed.yml
+++ b/examples/cpp-cmake-codspeed.yml
@@ -27,7 +27,7 @@ jobs:
           make -j
 
       - name: Run C++ benchmarks
-        uses: CodSpeedHQ/action@v4
+        uses: CodSpeedHQ/action@v5
         with:
           mode: simulation
           run: ./path/to/built/benchmark

--- a/examples/go-codspeed.yml
+++ b/examples/go-codspeed.yml
@@ -26,7 +26,7 @@ jobs:
           go-version: stable
 
       - name: Run Go benchmarks
-        uses: CodSpeedHQ/action@main
+        uses: CodSpeedHQ/action@v5
         with:
           mode: walltime # go only supports walltime mode
           run: go test -bench=. -benchtime=5s

--- a/examples/nodejs-typescript-codspeed.yml
+++ b/examples/nodejs-typescript-codspeed.yml
@@ -26,7 +26,7 @@ jobs:
         run: npm install
 
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@v4
+        uses: CodSpeedHQ/action@v5
         with:
           mode: simulation
           run: node -r esbuild-register benches/bench.ts

--- a/examples/python-pytest-codspeed.yml
+++ b/examples/python-pytest-codspeed.yml
@@ -28,7 +28,7 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@v4
+        uses: CodSpeedHQ/action@v5
         with:
           mode: simulation
           run: pytest tests/ --codspeed

--- a/examples/rust-cargo-codspeed.yml
+++ b/examples/rust-cargo-codspeed.yml
@@ -31,7 +31,7 @@ jobs:
         run: cargo codspeed build
 
       - name: Run the benchmarks
-        uses: CodSpeedHQ/action@v4
+        uses: CodSpeedHQ/action@v5
         with:
           mode: simulation
           run: cargo codspeed run


### PR DESCRIPTION
v5.0.0 is out, so the README usage snippets and the language examples now point at it.

The Go example was still pinned to `@main`, it now uses `v5` like the others.

Refs COD-3244 (kept open, it tracks the runner release itself)
