### PR TITLE
feat: add cycle-estimation and exclude-allocations inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,3 +162,18 @@ jobs:
         with:
           mode: memory
           config: .github/test-codspeed.yml
+
+  test-simulation-tuning-inputs:
+    runs-on: ubuntu-latest
+    env:
+      CODSPEED_SKIP_UPLOAD: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check action with cycle-estimation and exclude-allocations
+        uses: ./
+        with:
+          allow-empty: true
+          mode: simulation
+          cycle-estimation: "false"
+          exclude-allocations: "true"
+          run: echo "Testing simulation tuning inputs!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
       - "**.md"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-action:
     strategy:

--- a/README.md
+++ b/README.md
@@ -78,6 +78,19 @@ GitHub Actions for running [CodSpeed](https://codspeed.io) in your CI.
     # [OPTIONAL]
     # The version of the go-runner to use (e.g., 1.0.0, 1.0.0-beta.1). If not specified, the latest version will be installed
     go-runner-version: ""
+
+    # [OPTIONAL]
+    # Improve `simulation` accuracy by weighting each instruction by its estimated cycle
+    # cost instead of charging every instruction the same fixed cost.
+    # Set to "false" to disable. Requires runner v5 or later.
+    # Defaults to "true".
+    cycle-estimation: ""
+
+    # [OPTIONAL]
+    # Exclude memory allocation time from `simulation` mode results. Set to "true" to
+    # enable. Requires runner v5 or later.
+    # Defaults to "false".
+    exclude-allocations: ""
 ```
 
 # Example usage

--- a/action.yml
+++ b/action.yml
@@ -78,6 +78,19 @@ inputs:
     description: "The version of the go-runner to use (e.g., 1.0.0, 1.0.0-beta.1). If not specified, the latest version will be installed"
     required: false
 
+  cycle-estimation:
+    description: |
+      Improve `simulation` accuracy by weighting each instruction by its estimated cycle cost instead of
+      charging every instruction the same fixed cost. Set to 'false' to disable.
+      Requires runner v5 or later. Defaults to 'true'.
+    required: false
+
+  exclude-allocations:
+    description: |
+      Exclude memory allocation time from `simulation` mode results. Set to 'true' to enable.
+      Requires runner v5 or later. Defaults to 'false'.
+    required: false
+
   config:
     description: "Path to a CodSpeed configuration file (codspeed.yml). If not specified, the runner will look for a codspeed.yml file in the repository root."
     required: false
@@ -262,6 +275,12 @@ runs:
         fi
         if [ -n "${{ inputs.config }}" ]; then
           RUNNER_ARGS+=(--config="${{ inputs.config }}")
+        fi
+        if [ -n "${{ inputs.cycle-estimation }}" ]; then
+          RUNNER_ARGS+=(--cycle-estimation="${{ inputs.cycle-estimation }}")
+        fi
+        if [ -n "${{ inputs.exclude-allocations }}" ]; then
+          RUNNER_ARGS+=(--exclude-allocations="${{ inputs.exclude-allocations }}")
         fi
 
         if [ -n "$CODSPEED_INPUT_RUN" ]; then


### PR DESCRIPTION
Both map to the runner's --cycle-estimation/--exclude-allocations flags and
are only forwarded when set, so unset runs keep the runner defaults and
pinned runners without the flags keep working.
