### PR TITLE
fix: add the distribution to the instruments cache key

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -139,6 +139,16 @@ runs:
         KERNEL_VERSION=$(uname -r)
         echo "kernel-version=$KERNEL_VERSION" >> $GITHUB_OUTPUT
 
+        # Get the distribution for the cache key: instrument installations are built against a
+        # specific release, and `runner.os` only says `Linux`
+        if [ -r /etc/os-release ]; then
+          . /etc/os-release
+          DISTRO="$ID-$VERSION_ID"
+        else
+          DISTRO="${{ runner.os }}"
+        fi
+        echo "distro=$DISTRO" >> $GITHUB_OUTPUT
+
         # Normalize mode for cache key (commas are not allowed in cache keys)
         MODE_CACHE_KEY=$(echo "${{ inputs.mode }}" | tr ',' '-')
         echo "mode-cache-key=$MODE_CACHE_KEY" >> $GITHUB_OUTPUT
@@ -148,9 +158,9 @@ runs:
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: ${{ inputs.instruments-cache-dir }}
-        key: codspeed-instruments-${{ steps.versions.outputs.mode-cache-key }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.versions.outputs.kernel-version }}-${{ steps.versions.outputs.runner-version }}
+        key: codspeed-instruments-${{ steps.versions.outputs.mode-cache-key }}-${{ steps.versions.outputs.distro }}-${{ runner.arch }}-${{ steps.versions.outputs.kernel-version }}-${{ steps.versions.outputs.runner-version }}
         restore-keys: |
-          codspeed-instruments-${{ steps.versions.outputs.mode-cache-key }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.versions.outputs.kernel-version }}-
+          codspeed-instruments-${{ steps.versions.outputs.mode-cache-key }}-${{ steps.versions.outputs.distro }}-${{ runner.arch }}-${{ steps.versions.outputs.kernel-version }}-
 
     - name: Lookup installer hash
       id: installer-hash


### PR DESCRIPTION
`runner.os` evaluates to `Linux`, and the kernel version does not imply a release: containers report their host's kernel, and two images of different releases can ship the same one. Entries built against one release were therefore restored on another, and an Ubuntu 26.04 job could pick up a valgrind tree built for 24.04.

Refs COD-3306