### PR TITLE
feat: add simulation-track-subprocess input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,11 +172,12 @@ jobs:
       CODSPEED_SKIP_UPLOAD: true
     steps:
       - uses: actions/checkout@v4
-      - name: Check action with cycle-estimation and exclude-allocations
+      - name: Check action with cycle-estimation, exclude-allocations and simulation-track-subprocess
         uses: ./
         with:
           allow-empty: true
           mode: simulation
           cycle-estimation: "false"
           exclude-allocations: "true"
+          simulation-track-subprocess: "true"
           run: echo "Testing simulation tuning inputs!"

--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ GitHub Actions for running [CodSpeed](https://codspeed.io) in your CI.
     # enable. Requires runner v5 or later.
     # Defaults to "false".
     exclude-allocations: ""
+
+    # [OPTIONAL]
+    # Measure the subprocesses spawned by the benchmarked process in `simulation` mode.
+    # Set to "true" to enable. Requires runner v5.2.0 or later.
+    # Defaults to "false".
+    simulation-track-subprocess: ""
 ```
 
 # Example usage

--- a/action.yml
+++ b/action.yml
@@ -91,6 +91,12 @@ inputs:
       Requires runner v5 or later. Defaults to 'false'.
     required: false
 
+  simulation-track-subprocess:
+    description: |
+      Measure the subprocesses spawned by the benchmarked process in `simulation` mode. Set to 'true' to enable.
+      Requires runner v5.2.0 or later. Defaults to 'false'.
+    required: false
+
   config:
     description: "Path to a CodSpeed configuration file (codspeed.yml). If not specified, the runner will look for a codspeed.yml file in the repository root."
     required: false
@@ -291,6 +297,9 @@ runs:
         fi
         if [ -n "${{ inputs.exclude-allocations }}" ]; then
           RUNNER_ARGS+=(--exclude-allocations="${{ inputs.exclude-allocations }}")
+        fi
+        if [ "${{ inputs.simulation-track-subprocess }}" = "true" ]; then
+          RUNNER_ARGS+=(--simulation-track-subprocess)
         fi
 
         if [ -n "$CODSPEED_INPUT_RUN" ]; then


### PR DESCRIPTION
Expose the runner's `--simulation-track-subprocess` flag as an action input, so
that subprocesses spawned by the benchmarked process are measured in
`simulation` mode.

Until now the only way to enable it from the action was the
`CODSPEED_SIMULATION_TRACK_SUBPROCESS` environment variable.

The flag stays opt-in here: it will be enabled by default in the next runner
major, since that changes existing measurements.
