### PR TITLE
feat: add memory-track-physical experimental input

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ GitHub Actions for running [CodSpeed](https://codspeed.io) in your CI.
     # Set to "true" to enable. Requires runner v5.2.0 or later.
     # Defaults to "false".
     simulation-track-subprocess: ""
+
+    # [OPTIONAL]
+    # [Experimental] Track physical (resident) memory in `memory` mode. Set to "true" to
+    # enable. Requires runner v5.3.0 or later.
+    # Defaults to "false".
+    experimental-memory-track-physical: ""
 ```
 
 # Example usage

--- a/action.yml
+++ b/action.yml
@@ -97,6 +97,12 @@ inputs:
       Requires runner v5.2.0 or later. Defaults to 'false'.
     required: false
 
+  experimental-memory-track-physical:
+    description: |
+      [Experimental] Track physical (resident) memory in `memory` mode. Set to 'true' to enable.
+      Requires runner v5.3.0 or later. Defaults to 'false'.
+    required: false
+
   config:
     description: "Path to a CodSpeed configuration file (codspeed.yml). If not specified, the runner will look for a codspeed.yml file in the repository root."
     required: false
@@ -300,6 +306,10 @@ runs:
         fi
         if [ "${{ inputs.simulation-track-subprocess }}" = "true" ]; then
           RUNNER_ARGS+=(--simulation-track-subprocess)
+        fi
+
+        if [ "${{ inputs.experimental-memory-track-physical }}" = "true" ]; then
+          RUNNER_ARGS+=(--experimental-memory-track-physical)
         fi
 
         if [ -n "$CODSPEED_INPUT_RUN" ]; then


### PR DESCRIPTION
Exposes the runner's `--memory-track-physical` experimental flag (physical/resident memory tracking in `memory` mode) as a new opt-in action input.

Depends on CodSpeedHQ/codspeed#529.

Not mergeable until that PR ships in a runner v5.3.0 release — the pinned installer version (`.codspeed-runner-version`, currently `5.0.1`) predates the flag, so no CI job exercises it yet.